### PR TITLE
Improve performance state index updates by using incremental updates

### DIFF
--- a/src/Index/AbstractStorage.php
+++ b/src/Index/AbstractStorage.php
@@ -94,7 +94,7 @@ abstract class AbstractStorage implements Storage
         $this->save($this->docs, [self::ID => $docId], $doc);
     }
 
-    abstract public function saveStates(array $states): void;
+    abstract public function saveStates(array $new, array $deleted): void;
 
     public function loadDocument(string|int $docId): array
     {

--- a/src/Index/DbalIndex.php
+++ b/src/Index/DbalIndex.php
@@ -136,6 +136,21 @@ class DbalIndex implements Index
         );
     }
 
+    public function deleteMultiple(string $key, array $data): void
+    {
+        $this->conn->executeStatement(
+            sprintf(
+                'DELETE FROM %s WHERE %s in %s',
+                $this->tableName,
+                $key,
+                implode(', ', array_map(
+                    fn (array $row) => '(' . implode(', ', $row) . ')',
+                    $data
+                ))
+            )
+        );
+    }
+
     public function truncate(): void
     {
         $this->conn->executeStatement(

--- a/src/Index/DbalIndex.php
+++ b/src/Index/DbalIndex.php
@@ -82,7 +82,7 @@ class DbalIndex implements Index
             array_filter([
                 new DoctrineIndex(
                     'primary',
-                    match (true) {
+                    match (true) { /** @phpstan-ignore match.unhandled */
                         in_array(DbalStorage::KEY, $columns) => [DbalStorage::KEY],
                         in_array(DbalStorage::ID, $columns) => [DbalStorage::ID],
                         in_array(DbalStorage::STATE, $columns) => [DbalStorage::STATE],
@@ -92,7 +92,7 @@ class DbalIndex implements Index
                 ),
                 in_array(DbalStorage::STATE, $columns) ? new DoctrineIndex(
                     sprintf('%s_state', $this->tableName),
-                    [DBALStorage::STATE]
+                    [DbalStorage::STATE]
                 ) : null,
             ])
         );

--- a/src/Index/DbalStorage.php
+++ b/src/Index/DbalStorage.php
@@ -90,13 +90,21 @@ class DbalStorage extends AbstractStorage implements Storage
     /**
      * @inheritdoc
      */
-    public function saveStates(array $states): void
+    public function saveStates(array $new, array $deleted): void
     {
-        $this->state->truncate();
-        $this->state->insertMultiple(
-            [DbalStorage::STATE],
-            array_map(fn($state) => [$state], $states)
-        );
+        if (count($new) > 0) {
+            $this->state->insertMultiple(
+                [DbalStorage::STATE],
+                array_map(fn($state) => [$state], $new)
+            );
+        }
+
+        if (count($deleted) > 0) {
+            $this->state->deleteMultiple(
+                DbalStorage::STATE,
+                array_map(fn($state) => [$state], $deleted)
+            );
+        }
     }
 
 

--- a/src/Index/DbalStorage.php
+++ b/src/Index/DbalStorage.php
@@ -21,6 +21,15 @@ use PHPhinder\Utils\StringHelper;
 
 class DbalStorage extends AbstractStorage implements Storage
 {
+    /** @var DbalIndex  */
+    protected Index $state;
+
+    /** @var DbalIndex */
+    protected Index $docs;
+
+    /** @var array<string, DbalIndex> */
+    protected array $indices = [];
+
     public function __construct(
         private readonly string $connectionString,
         Schema $schema = new DefaultSchema(),
@@ -53,7 +62,7 @@ class DbalStorage extends AbstractStorage implements Storage
     {
         if (!$this->docs->isCreated()) {
             $this->docs->create(array_merge([self::ID], array_keys(
-                array_filter($this->schemaVariables, fn ($var) => $var & Schema::IS_STORED)
+                array_filter($this->schemaVariables, fn ($var) => boolval($var & Schema::IS_STORED))
             )));
         }
 
@@ -136,6 +145,7 @@ class DbalStorage extends AbstractStorage implements Storage
 
     /**
      * @inheritDoc
+     * @param DbalIndex $index
      */
     protected function loadByStates(Index $index, array $states): \Generator
     {

--- a/src/Index/JsonStorage.php
+++ b/src/Index/JsonStorage.php
@@ -91,18 +91,18 @@ class JsonStorage extends AbstractStorage implements Storage
     /**
      * @inheritdoc
      */
-    public function saveStates(array $states): void
+    public function saveStates(array $new, array $deleted): void
     {
-        ftruncate($this->state->getHandler(), 0);
-
         $this->state->lock();
-        foreach ($states as $state) {
-            $this->state->write(str_pad(
-                sprintf('{"s":%s}', $state),
-                $this->state->getLength() - 1
-            ) . PHP_EOL);
+        foreach ($new as $state) {
+            $this->save($this->state, [self::STATE => $state], [self::STATE => $state]);
+        }
+
+        foreach ($deleted as $state) {
+            $this->remove($this->state, [self::STATE => $state]);
         }
         $this->state->unlock();
+
     }
 
     /**

--- a/src/Index/StateSet.php
+++ b/src/Index/StateSet.php
@@ -24,6 +24,17 @@ class StateSet implements StateSetInterface
      */
     private ?array $states = null;
 
+
+    /**
+     * @var array<int>
+     */
+    private array $new = [];
+
+    /**
+     * @var array<int, bool>
+     */
+    private array $deleted = [];
+
     public function __construct(private Storage $storage)
     {
     }
@@ -32,7 +43,10 @@ class StateSet implements StateSetInterface
     public function add(int $state): void
     {
         $this->initialize();
-        $this->states[$state] = true;
+        if (!$this->has($state)) {
+            $this->new[] = $state;
+            $this->states[$state] = true;
+        }
     }
 
     public function all(): array
@@ -50,13 +64,18 @@ class StateSet implements StateSetInterface
     public function remove(int $state): void
     {
         $this->initialize();
-        unset($this->states[$state]);
+        if ($this->has($state)) {
+            $this->deleted[] = $state;
+            unset($this->states[$state]);
+        }
     }
 
     public function persist(): void
     {
         $this->initialize();
-        $this->storage->saveStates(array_keys($this->states));
+        $this->storage->saveStates($this->new, $this->deleted);
+        $this->new = [];
+        $this->deleted = [];
     }
 
     private function initialize(): void

--- a/src/Index/StateSet.php
+++ b/src/Index/StateSet.php
@@ -31,7 +31,7 @@ class StateSet implements StateSetInterface
     private array $new = [];
 
     /**
-     * @var array<int, bool>
+     * @var array<int>
      */
     private array $deleted = [];
 
@@ -52,7 +52,7 @@ class StateSet implements StateSetInterface
     public function all(): array
     {
         $this->initialize();
-        return array_keys($this->states);
+        return array_keys($this->states ?? []);
     }
 
     public function has(int $state): bool

--- a/src/Index/Storage.php
+++ b/src/Index/Storage.php
@@ -47,10 +47,12 @@ interface Storage
     public function saveIndices(string $docId, array $data): void;
 
     /**
-     * Saves an state (if it doesn't exists) on the Storage.
-     * @param array<int> $states
+     * Saves states (if they don't exists) on the Storage, also
+     * removes deleted states.
+     * @param array<int> $new
+     * @param array<int> $deleted
      */
-    public function saveStates(array $states): void;
+    public function saveStates(array $new, array $deleted): void;
 
     /**
      * @return \Generator<int>

--- a/src/SearchEngine.php
+++ b/src/SearchEngine.php
@@ -308,7 +308,7 @@ class SearchEngine
         foreach ($result->getIndices() as $index) {
             if (isset($terms[$index])) {
                 $score += $this->boostTermByIndex($terms[$index], $result->getTerms(), $score);
-            } else if (isset($terms[self::ANY_SYMBOL])) {
+            } elseif (isset($terms[self::ANY_SYMBOL])) {
                 $score += $this->boostTermByIndex($terms[self::ANY_SYMBOL], $result->getTerms(), $score);
             }
         }

--- a/src/Transformer/StemmerTransformer.php
+++ b/src/Transformer/StemmerTransformer.php
@@ -19,7 +19,7 @@ class StemmerTransformer implements Transformer
     use TransformerTrait;
 
     /** @var Filter[] */
-    private array $filters=[];
+    private array $filters = [];
     private Stemmer $stemmer;
 
     public function __construct(string $langIso = 'en', string ...$filters)

--- a/src/Transformer/SymbolTransformer.php
+++ b/src/Transformer/SymbolTransformer.php
@@ -16,7 +16,7 @@ class SymbolTransformer implements Transformer
     use TransformerTrait;
 
     /** @var array<Filter> */
-    private array $filters=[];
+    private array $filters = [];
 
     public function __construct(string $langIso = 'en', string ...$filters)
     {

--- a/src/Utils/IDEncoder.php
+++ b/src/Utils/IDEncoder.php
@@ -16,7 +16,8 @@ class IDEncoder
     private const ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
     private const BASE = 62;
 
-    public static function encode(int $number): string {
+    public static function encode(int $number): string
+    {
         if ($number === 0) {
             return self::ALPHABET[0];
         }
@@ -31,7 +32,8 @@ class IDEncoder
         return $result;
     }
 
-    public static function decode(string $encoded): int {
+    public static function decode(string $encoded): int
+    {
         $length = strlen($encoded);
         $number = 0;
 
@@ -43,7 +45,8 @@ class IDEncoder
     }
 
     // Custom comparison function
-    public static function compare(string $a, string $b): int {
+    public static function compare(string $a, string $b): int
+    {
         $decodedA = self::decode($a);
         $decodedB = self::decode($b);
         return $decodedA <=> $decodedB;

--- a/src/Utils/StringHelper.php
+++ b/src/Utils/StringHelper.php
@@ -11,11 +11,12 @@
 
 namespace PHPhinder\Utils;
 
-class StringHelper {
+class StringHelper
+{
     public static function getShortClass(string $className, string $separator = '_'): string
     {
         $separator = strrpos($className, '\\');
-        $className = substr($className,  $separator ? $separator + 1 : 0);
+        $className = substr($className, $separator ? $separator + 1 : 0);
         $simplified = preg_split('/(?<=[a-z])(?=[A-Z])/u', $className);
         if (!is_array($simplified)) {
             throw new \InvalidArgumentException('Class name could not be parsed: ' . $className);

--- a/tests/Stress/AliceSearchEngineTest.php
+++ b/tests/Stress/AliceSearchEngineTest.php
@@ -97,7 +97,7 @@ class AliceSearchEngineTest extends TestCase
             ['Hatter', 0.05, 57],
             ['gryphon', 0.15, 55],
             ['griphon', 0.15, 55],
-            ['winder', 0.3, 36], //winter, wander, wider, wonder
+            ['winder', 0.3, 35], //winter, wander, wider, wonder
         ];
     }
 }


### PR DESCRIPTION
Instead of writing the full state index for every commit, write only new or deleted states. 

Also some cleaning and standardization (also typo fixing) with `phpcs` and `phpstan` assistance.